### PR TITLE
Change base image to zquestz/bitcoin-cash-node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SRC_IMAGE=bitcoinabc/bitcoin-abc-bchn
+ARG SRC_IMAGE=zquestz/bitcoin-cash-node
 ARG SRC_IMAGE_TAG=latest
 FROM $SRC_IMAGE:$SRC_IMAGE_TAG
 


### PR DESCRIPTION
SSIA, tested in dev env
`bitcoinabc/bitcoin-abc-bchn` is outdated, `zquestz/bitcoin-cash-node` specified as official image on [bscn download page](https://bitcoincashnode.org/en/download.html)